### PR TITLE
feat: allow for value to be opt

### DIFF
--- a/src/cli/transform/generators/typescript.ts
+++ b/src/cli/transform/generators/typescript.ts
@@ -32,7 +32,7 @@ function getAstNodes(document: Document) {
           factory.createPropertySignature(
             undefined,
             factory.createIdentifier("value"),
-            undefined,
+            factory.createToken(ts.SyntaxKind.QuestionToken),
             flag.variants
               ? factory.createUnionTypeNode(
                   flag.variants?.map((variant) =>


### PR DESCRIPTION
Not all flags have variants, and boolean flags never do. I think we should make `value` be optional

## Example features.yml

```yaml
version: "1.2"
namespace: default
flags:
- key: new-feature
  name: new feature
  type: BOOLEAN_FLAG_TYPE
  enabled: true
- key: maintenance-mode
  name: maintenance mode
  type: BOOLEAN_FLAG_TYPE
  description: Put application in maintenance mode
  enabled: false
- key: vvv
  name: vvv
  type: VARIANT_FLAG_TYPE
  enabled: false
  variants:
  - key: one
  - key: two
segments:
- key: beta-users
  name: beta users
  constraints:
  - type: BOOLEAN_COMPARISON_TYPE
    property: is_beta
    operator: "true"
  match_type: ANY_MATCH_TYPE
```

## flipt.ts

```typescript
// Generated by @flipt-io/typed
export type Flag = {
    key: "new-feature";
    value?: unknown;
} | {
    key: "maintenance-mode";
    value?: unknown;
} | {
    key: "vvv";
    value?: "one" | "two";
};
export type Context = {
    is_beta: boolean;
};
```